### PR TITLE
feat (bug-fix): enhance CLI scaffolding with new options and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ grit new myapp --triple --next       # Web + Admin + API (Next.js)
 grit new myapp --double --vite       # Web + API (TanStack Router)
 grit new myapp --single              # Single Go binary + embedded SPA
 grit new myapp --api                 # Go API only
+grit new . --triple --vite           # Scaffold into current directory
+grit new ./ --triple --vite          # Same as above
 grit new-desktop myapp               # Native desktop app (Wails)
 ```
+
+Tip: when using `grit new .`, Grit infers the project name from your current folder name. Use `--force` if the directory is non-empty.
 
 ```bash
 cd myapp
@@ -114,6 +118,7 @@ grit remove resource Post
 # Scaffolding
 grit new <name>                        # Interactive (architecture + frontend)
 grit new <name> --triple --next        # Explicit flags
+grit new . --triple --vite             # Scaffold into current directory
 grit new-desktop <name>                # Desktop app (Wails)
 
 # Code generation

--- a/cmd/grit/main.go
+++ b/cmd/grit/main.go
@@ -147,16 +147,23 @@ func newCmd() *cobra.Command {
 				return fmt.Errorf("invalid frontend %q: must be next, vite, or tanstack", frontendFlag)
 			}
 
-			// Apply legacy flag mappings
-			opts.Normalize()
+			// Show interactive selector only when the user did not provide any
+			// architecture/frontend shortcuts or explicit long-form flags.
+			anyScaffoldSelection := cmd.Flags().Changed("arch") ||
+				cmd.Flags().Changed("frontend") ||
+				cmd.Flags().Changed("single") ||
+				cmd.Flags().Changed("double") ||
+				cmd.Flags().Changed("triple") ||
+				cmd.Flags().Changed("vite") ||
+				cmd.Flags().Changed("next") ||
+				cmd.Flags().Changed("api") ||
+				cmd.Flags().Changed("mobile") ||
+				cmd.Flags().Changed("expo") ||
+				cmd.Flags().Changed("full")
 
-			// Only show interactive prompt if NO explicit flags were set
-			anyFlagSet := archFlag != "" || frontendFlag != "" ||
-				apiOnly || mobileOnly || full || includeExpo
-
-			if !anyFlagSet {
+			if !anyScaffoldSelection {
 				printLogo()
-				// Reset to empty so prompt shows
+				// Keep empty values so the prompt can collect architecture/frontend.
 				opts.Architecture = ""
 				opts.Frontend = ""
 				if err := prompt.RunNewProjectPrompt(&opts); err != nil {

--- a/cmd/grit/main.go
+++ b/cmd/grit/main.go
@@ -67,40 +67,54 @@ func versionCmd() *cobra.Command {
 func newCmd() *cobra.Command {
 	// New architecture/frontend flags
 	var archFlag, frontendFlag, style string
+	var inPlace, force bool
 
 	// Legacy flags (backward compatibility)
 	var apiOnly, includeExpo, mobileOnly, full bool
 
 	cmd := &cobra.Command{
-		Use:   "new <project-name>",
+		Use:   "new <project-name|.>",
 		Short: "Create a new Grit project",
-		Long:  "Scaffold a new Grit project. Interactive by default — select architecture and frontend.\nUse flags to skip prompts: grit new my-app --single --vite",
+		Long:  "Scaffold a new Grit project. Interactive by default — select architecture and frontend.\nUse flags to skip prompts: grit new my-app --single --vite\nUse `grit new .` to scaffold in the current directory.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			projectName := args[0]
+			projectArg := strings.TrimSpace(args[0])
+			projectName := projectArg
 
-			// Support "grit new ." to scaffold into current directory
-			if projectName == "." {
+			if filepath.Clean(projectArg) == "." {
 				cwd, err := os.Getwd()
 				if err != nil {
 					return fmt.Errorf("getting current directory: %w", err)
 				}
 				projectName = filepath.Base(cwd)
-			} else {
-				if err := scaffold.ValidateProjectName(projectName); err != nil {
-					return err
+				inPlace = true
+			}
+
+			if err := scaffold.ValidateProjectName(projectName); err != nil {
+				if filepath.Clean(projectArg) == "." {
+					return fmt.Errorf("invalid current directory name %q for project generation: %w", projectName, err)
 				}
+				return err
 			}
 
 			opts := scaffold.Options{
 				ProjectName: projectName,
 				InPlace:     args[0] == ".",
 				Style:       style,
+				InPlace:     inPlace,
+				Force:       force,
 				// Legacy flags
 				APIOnly:     apiOnly,
 				IncludeExpo: includeExpo,
 				MobileOnly:  mobileOnly,
 				Full:        full,
+			}
+
+			if !opts.InPlace {
+				cwd, err := os.Getwd()
+				if err == nil && filepath.Base(cwd) == projectName {
+					opts.InPlace = true
+				}
 			}
 
 			// Map architecture shorthand flags
@@ -215,14 +229,16 @@ func newCmd() *cobra.Command {
 	cmd.Flags().Bool("single", false, "Shorthand for --arch=single")
 	cmd.Flags().Bool("double", false, "Shorthand for --arch=double")
 	cmd.Flags().Bool("triple", false, "Shorthand for --arch=triple")
+	cmd.Flags().BoolVar(&inPlace, "here", false, "Scaffold into the current directory instead of creating a new folder")
+	cmd.Flags().BoolVar(&force, "force", false, "Allow scaffolding into a non-empty directory (use with --here)")
 
 	return cmd
 }
 
 func generateCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "generate",
-		Short: "Generate code for your Grit project",
+		Use:     "generate",
+		Short:   "Generate code for your Grit project",
 		Aliases: []string{"g"},
 	}
 
@@ -233,8 +249,8 @@ func generateCmd() *cobra.Command {
 
 func removeCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "remove",
-		Short: "Remove components from your Grit project",
+		Use:     "remove",
+		Short:   "Remove components from your Grit project",
 		Aliases: []string{"rm"},
 	}
 
@@ -741,7 +757,9 @@ func printSuccess(name string, opts scaffold.Options) {
 
 	white.Println("  Next steps:")
 	fmt.Println()
-	cyan.Printf("    cd %s\n", name)
+	if !opts.InPlace {
+		cyan.Printf("    cd %s\n", name)
+	}
 	cyan.Println("    docker compose up -d")
 
 	switch opts.Architecture {

--- a/cmd/grit/main.go
+++ b/cmd/grit/main.go
@@ -99,7 +99,6 @@ func newCmd() *cobra.Command {
 
 			opts := scaffold.Options{
 				ProjectName: projectName,
-				InPlace:     args[0] == ".",
 				Style:       style,
 				InPlace:     inPlace,
 				Force:       force,

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -169,6 +169,63 @@ func ValidateProjectName(name string) error {
 	return nil
 }
 
+func resolveScaffoldRoot(opts Options) (string, bool, error) {
+	if opts.InPlace {
+		return ".", true, nil
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false, fmt.Errorf("getting current directory: %w", err)
+	}
+
+	// Quality-of-life behavior: if the user is already inside a directory whose
+	// name matches the project name, scaffold in place instead of nesting.
+	if filepath.Base(cwd) == opts.ProjectName {
+		return ".", true, nil
+	}
+
+	return opts.ProjectName, false, nil
+}
+
+func ensureTargetDirectory(root string, inPlace bool, force bool) error {
+	if !inPlace {
+		if _, err := os.Stat(root); err == nil {
+			return fmt.Errorf("directory %q already exists", root)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("checking directory %q: %w", root, err)
+		}
+		return nil
+	}
+
+	info, err := os.Stat(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if err := os.MkdirAll(root, 0755); err != nil {
+				return fmt.Errorf("creating directory %q: %w", root, err)
+			}
+			return nil
+		}
+		return fmt.Errorf("checking directory %q: %w", root, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("target %q is not a directory", root)
+	}
+	if force {
+		return nil
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return fmt.Errorf("reading directory %q: %w", root, err)
+	}
+	if len(entries) > 0 {
+		return fmt.Errorf("current directory is not empty; rerun with --force to scaffold in place")
+	}
+
+	return nil
+}
+
 // Run executes the full scaffolding process.
 func Run(opts Options) error {
 	opts.Normalize()

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -45,6 +45,110 @@ func TestValidateProjectName(t *testing.T) {
 	}
 }
 
+func TestResolveScaffoldRoot(t *testing.T) {
+	t.Run("explicit in-place", func(t *testing.T) {
+		root, inPlace, err := resolveScaffoldRoot(Options{ProjectName: "my-app", InPlace: true})
+		if err != nil {
+			t.Fatalf("resolveScaffoldRoot returned error: %v", err)
+		}
+		if root != "." {
+			t.Fatalf("root = %q, want .", root)
+		}
+		if !inPlace {
+			t.Fatal("inPlace = false, want true")
+		}
+	})
+
+	t.Run("auto in-place when cwd matches project name", func(t *testing.T) {
+		prev, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("getwd: %v", err)
+		}
+
+		target := filepath.Join(t.TempDir(), "my-app")
+		if err := os.MkdirAll(target, 0755); err != nil {
+			t.Fatalf("mkdirall: %v", err)
+		}
+		if err := os.Chdir(target); err != nil {
+			t.Fatalf("chdir target: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = os.Chdir(prev)
+		})
+
+		root, inPlace, err := resolveScaffoldRoot(Options{ProjectName: "my-app"})
+		if err != nil {
+			t.Fatalf("resolveScaffoldRoot returned error: %v", err)
+		}
+		if root != "." {
+			t.Fatalf("root = %q, want .", root)
+		}
+		if !inPlace {
+			t.Fatal("inPlace = false, want true")
+		}
+	})
+
+	t.Run("default creates named directory", func(t *testing.T) {
+		root, inPlace, err := resolveScaffoldRoot(Options{ProjectName: "my-app"})
+		if err != nil {
+			t.Fatalf("resolveScaffoldRoot returned error: %v", err)
+		}
+		if root != "my-app" {
+			t.Fatalf("root = %q, want my-app", root)
+		}
+		if inPlace {
+			t.Fatal("inPlace = true, want false")
+		}
+	})
+}
+
+func TestEnsureTargetDirectory(t *testing.T) {
+	t.Run("non-in-place rejects existing directory", func(t *testing.T) {
+		root := filepath.Join(t.TempDir(), "existing")
+		if err := os.MkdirAll(root, 0755); err != nil {
+			t.Fatalf("mkdirall: %v", err)
+		}
+
+		err := ensureTargetDirectory(root, false, false)
+		if err == nil {
+			t.Fatal("expected error for existing directory, got nil")
+		}
+	})
+
+	t.Run("in-place allows empty directory", func(t *testing.T) {
+		root := t.TempDir()
+		if err := ensureTargetDirectory(root, true, false); err != nil {
+			t.Fatalf("ensureTargetDirectory returned error: %v", err)
+		}
+	})
+
+	t.Run("in-place rejects non-empty directory by default", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "placeholder.txt"), []byte("x"), 0644); err != nil {
+			t.Fatalf("writefile: %v", err)
+		}
+
+		err := ensureTargetDirectory(root, true, false)
+		if err == nil {
+			t.Fatal("expected error for non-empty directory, got nil")
+		}
+		if !strings.Contains(err.Error(), "--force") {
+			t.Fatalf("expected --force hint in error, got: %v", err)
+		}
+	})
+
+	t.Run("in-place force allows non-empty directory", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "placeholder.txt"), []byte("x"), 0644); err != nil {
+			t.Fatalf("writefile: %v", err)
+		}
+
+		if err := ensureTargetDirectory(root, true, true); err != nil {
+			t.Fatalf("ensureTargetDirectory returned error with force: %v", err)
+		}
+	})
+}
+
 // ── ValidateStyle ─────────────────────────────────────────────────────────────
 
 func TestValidateStyle(t *testing.T) {


### PR DESCRIPTION
This pull request adds support for scaffolding new Grit projects directly into the current directory (in-place), with safety checks and a `--force` flag to allow operation in non-empty directories. It updates the CLI, internal scaffolding logic, documentation, and adds comprehensive tests for the new behaviors.

**CLI and User Experience Improvements:**
- Added support for `grit new .` and `grit new ./` to scaffold into the current directory, inferring the project name from the folder. Introduced `--here` (in-place) and `--force` flags for controlling directory usage and overwriting. The CLI now automatically detects when the current directory matches the project name and scaffolds in place. [[1]](diffhunk://#diff-db3b8557e8d171d6d7a94004974763e49a16396c5389aac625964b5bb560e86eR70-R118) [[2]](diffhunk://#diff-db3b8557e8d171d6d7a94004974763e49a16396c5389aac625964b5bb560e86eR235-R236) [[3]](diffhunk://#diff-ebd5c924d46d2391db36f2f9eaec2b65d9dd63274af3f2468748d826638c1ae4R39-R40) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R44-R50) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R121)

**Scaffolding Logic Enhancements:**
- Refactored directory resolution and validation logic with new helper functions `resolveScaffoldRoot` and `ensureTargetDirectory`, handling in-place scaffolding and force-overwrite semantics. Updated both multi-app and single-app scaffolding flows to use this logic. [[1]](diffhunk://#diff-ebd5c924d46d2391db36f2f9eaec2b65d9dd63274af3f2468748d826638c1ae4R173-R229) [[2]](diffhunk://#diff-ebd5c924d46d2391db36f2f9eaec2b65d9dd63274af3f2468748d826638c1ae4L180-R244) [[3]](diffhunk://#diff-ebd5c924d46d2391db36f2f9eaec2b65d9dd63274af3f2468748d826638c1ae4L329-R395)

**User Feedback:**
- Improved post-scaffold instructions: omits the `cd` step if scaffolding was done in-place.

**Testing:**
- Added extensive unit tests for the new in-place and force behaviors, covering edge cases like directory emptiness and error handling.

**Documentation:**
- Updated the `README.md` to document the new in-place scaffolding commands and usage tips. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R44-R50) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R121)